### PR TITLE
BE 12: leaderboard

### DIFF
--- a/src/controllers/leaderboardController.test.ts
+++ b/src/controllers/leaderboardController.test.ts
@@ -1,0 +1,384 @@
+import request from 'supertest';
+import express from 'express';
+import * as leaderboardController from '../controllers/leaderboardController';
+import * as leaderboardDB from '../db/leaderboard';
+import * as categoryDB from '../db/category';
+
+jest.mock('../db/leaderboard');
+jest.mock('../db/category');
+jest.mock('../services/ExperienceCalculator');
+
+const app = express();
+app.use(express.json());
+
+app.get('/leaderboards', leaderboardController.getLeaderboard);
+
+const mockCategory = {
+  id: '11111111-1111-1111-1111-111111111111',
+  name: 'Fitness',
+};
+
+const mockStreakByCategoryData = [
+  {
+    rank: 1,
+    userId: 'user1',
+    username: 'testuser1',
+    habitId: 'habit1',
+    habitName: 'Morning Run',
+    categoryId: 'cat1',
+    categoryName: 'Fitness',
+    streakCount: 25,
+    isActive: true,
+  },
+  {
+    rank: 2,
+    userId: 'user2',
+    username: 'testuser2',
+    habitId: 'habit2',
+    habitName: 'Push ups',
+    categoryId: 'cat1',
+    categoryName: 'Fitness',
+    streakCount: 20,
+    isActive: false,
+  },
+];
+
+const mockStreakByUserData = [
+  {
+    rank: 1,
+    userId: 'user1',
+    username: 'testuser1',
+    streakCount: 30,
+    topStreakHabit: {
+      habitId: 'habit1',
+      habitName: 'Morning Run',
+      categoryId: 'cat1',
+      categoryName: 'Fitness',
+    },
+    isActive: true,
+  },
+  {
+    rank: 2,
+    userId: 'user2',
+    username: 'testuser2',
+    streakCount: 25,
+    topStreakHabit: {
+      habitId: 'habit2',
+      habitName: 'Reading',
+      categoryId: 'cat2',
+      categoryName: 'Learning',
+    },
+    isActive: false,
+  },
+];
+
+const mockLevelByCategoryData = [
+  {
+    rank: 1,
+    userId: 'user1',
+    username: 'testuser1',
+    categoryId: 'cat1',
+    categoryName: 'Fitness',
+    totalExperience: 2500,
+    level: 5,
+  },
+  {
+    rank: 2,
+    userId: 'user2',
+    username: 'testuser2',
+    categoryId: 'cat1',
+    categoryName: 'Fitness',
+    totalExperience: 1800,
+    level: 4,
+  },
+];
+
+const mockLevelByUserData = [
+  {
+    rank: 1,
+    userId: 'user1',
+    username: 'testuser1',
+    totalExperience: 5000,
+    totalLevel: 7,
+    categoriesCount: 3,
+    topCategory: {
+      categoryId: 'cat1',
+      categoryName: 'Fitness',
+      level: 4,
+      experience: 2500,
+    },
+  },
+  {
+    rank: 2,
+    userId: 'user2',
+    username: 'testuser2',
+    totalExperience: 3500,
+    totalLevel: 5,
+    categoriesCount: 2,
+    topCategory: {
+      categoryId: 'cat2',
+      categoryName: 'Learning',
+      level: 3,
+      experience: 2000,
+    },
+  },
+];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('Leaderboard Controller', () => {
+  describe('GET /leaderboards?type=streak-by-category', () => {
+    it('should return streak leaderboard by category successfully', async () => {
+      (categoryDB.findCategoryById as jest.Mock).mockResolvedValue(mockCategory);
+      (leaderboardDB.getTopStreaksByCategory as jest.Mock).mockResolvedValue(mockStreakByCategoryData);
+
+      const response = await request(app)
+        .get('/leaderboards?type=streak-by-category&categoryId=11111111-1111-1111-1111-111111111111&limit=10');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({
+        type: 'Streak by Category',
+        leaderboardType: 'streak-by-category',
+        categoryId: '11111111-1111-1111-1111-111111111111',
+        limit: 10,
+        entries: mockStreakByCategoryData,
+        count: 2,
+      });
+
+      expect(categoryDB.findCategoryById).toHaveBeenCalledWith('11111111-1111-1111-1111-111111111111');
+      expect(leaderboardDB.getTopStreaksByCategory).toHaveBeenCalledWith('11111111-1111-1111-1111-111111111111', 10);
+    });
+
+    it('should return 404 when category not found', async () => {
+      (categoryDB.findCategoryById as jest.Mock).mockResolvedValue(null);
+
+      const response = await request(app)
+        .get('/leaderboards?type=streak-by-category&categoryId=11111111-1111-1111-1111-111111111111');
+
+      expect(response.status).toBe(404);
+      expect(response.body).toEqual({ error: 'Category not found' });
+    });
+
+    it('should return 400 when categoryId is missing', async () => {
+      const response = await request(app)
+        .get('/leaderboards?type=streak-by-category');
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toBe('Invalid request parameters');
+    });
+  });
+
+  describe('GET /leaderboards?type=streak-by-user', () => {
+    it('should return streak leaderboard by user successfully', async () => {
+      (leaderboardDB.getTopStreaksByUser as jest.Mock).mockResolvedValue(mockStreakByUserData);
+
+      const response = await request(app)
+        .get('/leaderboards?type=streak-by-user&limit=5');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({
+        type: 'Streak by User',
+        leaderboardType: 'streak-by-user',
+        categoryId: null,
+        limit: 5,
+        entries: mockStreakByUserData,
+        count: 2,
+      });
+
+      expect(leaderboardDB.getTopStreaksByUser).toHaveBeenCalledWith(5);
+    });
+
+    it('should use default limit when not provided', async () => {
+      (leaderboardDB.getTopStreaksByUser as jest.Mock).mockResolvedValue(mockStreakByUserData);
+
+      const response = await request(app)
+        .get('/leaderboards?type=streak-by-user');
+
+      expect(response.status).toBe(200);
+      expect(response.body.limit).toBe(10);
+      expect(leaderboardDB.getTopStreaksByUser).toHaveBeenCalledWith(10);
+    });
+  });
+
+  describe('GET /leaderboards?type=level-by-category', () => {
+    it('should return level leaderboard by category successfully', async () => {
+      (categoryDB.findCategoryById as jest.Mock).mockResolvedValue(mockCategory);
+      (leaderboardDB.getTopLevelsByCategory as jest.Mock).mockResolvedValue(mockLevelByCategoryData);
+
+      const response = await request(app)
+        .get('/leaderboards?type=level-by-category&categoryId=11111111-1111-1111-1111-111111111111&limit=15');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({
+        type: 'Level by Category',
+        leaderboardType: 'level-by-category',
+        categoryId: '11111111-1111-1111-1111-111111111111',
+        limit: 15,
+        entries: mockLevelByCategoryData,
+        count: 2,
+      });
+
+      expect(categoryDB.findCategoryById).toHaveBeenCalledWith('11111111-1111-1111-1111-111111111111');
+      expect(leaderboardDB.getTopLevelsByCategory).toHaveBeenCalledWith('11111111-1111-1111-1111-111111111111', 15);
+    });
+
+    it('should return 400 when categoryId is missing', async () => {
+      const response = await request(app)
+        .get('/leaderboards?type=level-by-category');
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toBe('Invalid request parameters');
+    });
+  });
+
+  describe('GET /leaderboards?type=level-by-user', () => {
+    it('should return level leaderboard by user successfully', async () => {
+      (leaderboardDB.getTopLevelsByUser as jest.Mock).mockResolvedValue(mockLevelByUserData);
+
+      const response = await request(app)
+        .get('/leaderboards?type=level-by-user&limit=20');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({
+        type: 'Level by User',
+        leaderboardType: 'level-by-user',
+        categoryId: null,
+        limit: 20,
+        entries: mockLevelByUserData,
+        count: 2,
+      });
+
+      expect(leaderboardDB.getTopLevelsByUser).toHaveBeenCalledWith(20);
+    });
+  });
+
+  describe('Validation and Error Handling', () => {
+    it('should return 400 for invalid leaderboard type', async () => {
+      const response = await request(app)
+        .get('/leaderboards?type=invalid-type');
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toBe('Invalid request parameters');
+    });
+
+    it('should return 400 for invalid categoryId format', async () => {
+      const response = await request(app)
+        .get('/leaderboards?type=streak-by-category&categoryId=invalid-uuid');
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toBe('Invalid request parameters');
+    });
+
+    it('should return 400 for limit out of range', async () => {
+      const response = await request(app)
+        .get('/leaderboards?type=streak-by-user&limit=100');
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toBe('Invalid request parameters');
+    });
+
+    it('should return 400 for negative limit', async () => {
+      const response = await request(app)
+        .get('/leaderboards?type=streak-by-user&limit=-5');
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toBe('Invalid request parameters');
+    });
+
+    it('should handle database errors gracefully', async () => {
+      (leaderboardDB.getTopStreaksByUser as jest.Mock).mockRejectedValue(new Error('Database connection failed'));
+
+      const response = await request(app)
+        .get('/leaderboards?type=streak-by-user');
+
+      expect(response.status).toBe(500);
+      expect(response.body.error).toBe('Database connection failed');
+    });
+
+    it('should handle category lookup errors gracefully', async () => {
+      (categoryDB.findCategoryById as jest.Mock).mockRejectedValue(new Error('Category lookup failed'));
+
+      const response = await request(app)
+        .get('/leaderboards?type=streak-by-category&categoryId=11111111-1111-1111-1111-111111111111');
+
+      expect(response.status).toBe(500);
+      expect(response.body.error).toBe('Category lookup failed');
+    });
+  });
+
+  describe('Query Parameter Handling', () => {
+    it('should handle string limit conversion', async () => {
+      (leaderboardDB.getTopStreaksByUser as jest.Mock).mockResolvedValue(mockStreakByUserData);
+
+      const response = await request(app)
+        .get('/leaderboards?type=streak-by-user&limit=5');
+
+      expect(response.status).toBe(200);
+      expect(leaderboardDB.getTopStreaksByUser).toHaveBeenCalledWith(5);
+    });
+
+    it('should ignore categoryId for user-based leaderboards', async () => {
+      (leaderboardDB.getTopStreaksByUser as jest.Mock).mockResolvedValue(mockStreakByUserData);
+
+      const response = await request(app)
+        .get('/leaderboards?type=streak-by-user&categoryId=11111111-1111-1111-1111-111111111111');
+
+      expect(response.status).toBe(200);
+      expect(response.body.categoryId).toBe(null);
+      expect(categoryDB.findCategoryById).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Leaderboard Data Validation', () => {
+    it('should handle empty streak results gracefully', () => {
+      (leaderboardDB.getTopStreaksByCategory as jest.Mock).mockResolvedValue([]);
+      (categoryDB.findCategoryById as jest.Mock).mockResolvedValue(mockCategory);
+
+      return request(app)
+        .get('/leaderboards?type=streak-by-category&categoryId=11111111-1111-1111-1111-111111111111')
+        .expect(200)
+        .then(response => {
+          expect(response.body.entries).toEqual([]);
+          expect(response.body.count).toBe(0);
+        });
+    });
+
+    it('should handle empty user streak results gracefully', () => {
+      (leaderboardDB.getTopStreaksByUser as jest.Mock).mockResolvedValue([]);
+
+      return request(app)
+        .get('/leaderboards?type=streak-by-user')
+        .expect(200)
+        .then(response => {
+          expect(response.body.entries).toEqual([]);
+          expect(response.body.count).toBe(0);
+        });
+    });
+
+    it('should validate that mock data structure matches interface expectations', () => {
+      // Test that our mock data structure matches what the real functions should return
+      expect(mockStreakByCategoryData[0]).toHaveProperty('rank');
+      expect(mockStreakByCategoryData[0]).toHaveProperty('userId');
+      expect(mockStreakByCategoryData[0]).toHaveProperty('username');
+      expect(mockStreakByCategoryData[0]).toHaveProperty('habitId');
+      expect(mockStreakByCategoryData[0]).toHaveProperty('habitName');
+      expect(mockStreakByCategoryData[0]).toHaveProperty('categoryId');
+      expect(mockStreakByCategoryData[0]).toHaveProperty('categoryName');
+      expect(mockStreakByCategoryData[0]).toHaveProperty('streakCount');
+      expect(mockStreakByCategoryData[0]).toHaveProperty('isActive');
+
+      expect(mockStreakByUserData[0]).toHaveProperty('rank');
+      expect(mockStreakByUserData[0]).toHaveProperty('userId');
+      expect(mockStreakByUserData[0]).toHaveProperty('username');
+      expect(mockStreakByUserData[0]).toHaveProperty('streakCount');
+      expect(mockStreakByUserData[0]).toHaveProperty('topStreakHabit');
+      expect(mockStreakByUserData[0]).toHaveProperty('isActive');
+      expect(mockStreakByUserData[0].topStreakHabit).toHaveProperty('habitId');
+      expect(mockStreakByUserData[0].topStreakHabit).toHaveProperty('habitName');
+      expect(mockStreakByUserData[0].topStreakHabit).toHaveProperty('categoryId');
+      expect(mockStreakByUserData[0].topStreakHabit).toHaveProperty('categoryName');
+    });
+  });
+});

--- a/src/controllers/leaderboardController.ts
+++ b/src/controllers/leaderboardController.ts
@@ -1,0 +1,78 @@
+import { Request, Response } from 'express';
+import * as leaderboardDB from '../db/leaderboard';
+import * as categoryDB from '../db/category';
+import { leaderboardQuerySchema } from '../validators/leaderboardValidators';
+
+export const getLeaderboard = async (req: Request, res: Response) => {
+  try {
+    const queryParams = leaderboardQuerySchema.parse(req.query);
+    const { type, categoryId, limit } = queryParams;
+
+    if (categoryId) {
+      const category = await categoryDB.findCategoryById(categoryId);
+      if (!category) {
+        res.status(404).json({ error: 'Category not found' });
+        return;
+      }
+    }
+
+    let leaderboardData;
+    let leaderboardType: string;
+
+    switch (type) {
+      case 'streak-by-category':
+        if (!categoryId) {
+          res.status(400).json({ error: 'categoryId is required for streak-by-category leaderboard' });
+          return;
+        }
+        leaderboardData = await leaderboardDB.getTopStreaksByCategory(categoryId, limit);
+        leaderboardType = 'Streak by Category';
+        break;
+
+      case 'streak-by-user':
+        leaderboardData = await leaderboardDB.getTopStreaksByUser(limit);
+        leaderboardType = 'Streak by User';
+        break;
+
+      case 'level-by-category':
+        if (!categoryId) {
+          res.status(400).json({ error: 'categoryId is required for level-by-category leaderboard' });
+          return;
+        }
+        leaderboardData = await leaderboardDB.getTopLevelsByCategory(categoryId, limit);
+        leaderboardType = 'Level by Category';
+        break;
+
+      case 'level-by-user':
+        leaderboardData = await leaderboardDB.getTopLevelsByUser(limit);
+        leaderboardType = 'Level by User';
+        break;
+
+      default:
+        res.status(400).json({ error: 'Invalid leaderboard type' });
+        return;
+    }
+
+    res.status(200).json({
+      type: leaderboardType,
+      leaderboardType: type,
+      categoryId: categoryId || null,
+      limit,
+      entries: leaderboardData,
+      count: leaderboardData.length,
+    });
+  } catch (error: any) {
+    if (error.name === 'ZodError') {
+      res.status(400).json({ 
+        error: 'Invalid request parameters',
+        details: error.errors.map((err: any) => ({
+          field: err.path.join('.'),
+          message: err.message
+        }))
+      });
+    } else {
+      console.error('Leaderboard controller error:', error);
+      res.status(500).json({ error: error.message || 'An unexpected error occurred' });
+    }
+  }
+};

--- a/src/db/leaderboard.ts
+++ b/src/db/leaderboard.ts
@@ -1,0 +1,233 @@
+import { AppDataSource } from '../data-source';
+import { Streak } from '../entities/Streak';
+import { UserCategoryExperience } from '../entities/UserCategoryExperience';
+import { ensureDbConnected } from './index';
+import { ExperienceCalculator } from '../services/ExperienceCalculator';
+
+const streakRepository = AppDataSource.getRepository(Streak);
+const userCategoryExperienceRepo = AppDataSource.getRepository(UserCategoryExperience);
+
+export interface StreakLeaderboardEntry {
+  rank: number;
+  userId: string;
+  username: string;
+  habitId: string;
+  habitName: string;
+  categoryId: string;
+  categoryName: string;
+  streakCount: number;
+  isActive: boolean;
+}
+
+export interface UserStreakLeaderboardEntry {
+  rank: number;
+  userId: string;
+  username: string;
+  streakCount: number;
+  topStreakHabit: {
+    habitId: string;
+    habitName: string;
+    categoryId: string;
+    categoryName: string;
+  } | null;
+  isActive: boolean;
+}
+
+export interface CategoryLevelLeaderboardEntry {
+  rank: number;
+  userId: string;
+  username: string;
+  categoryId: string;
+  categoryName: string;
+  totalExperience: number;
+  level: number;
+}
+
+export interface UserLevelLeaderboardEntry {
+  rank: number;
+  userId: string;
+  username: string;
+  totalExperience: number;
+  totalLevel: number;
+  categoriesCount: number;
+  topCategory: {
+    categoryId: string;
+    categoryName: string;
+    level: number;
+    experience: number;
+  } | null;
+}
+
+export async function getTopStreaksByCategory(
+  categoryId: string,
+  limit: number = 10
+): Promise<StreakLeaderboardEntry[]> {
+  await ensureDbConnected();
+  
+  try {
+    // Use query builder with explicit joins for better reliability
+    const result = await streakRepository
+      .createQueryBuilder('streak')
+      .innerJoinAndSelect('streak.user', 'user')
+      .innerJoinAndSelect('streak.habit', 'habit')
+      .innerJoinAndSelect('habit.category', 'category')
+      .where('habit.categoryId = :categoryId', { categoryId })
+      .andWhere('streak.count > :minCount', { minCount: 0 })
+      .orderBy('streak.count', 'DESC')
+      .addOrderBy('streak.createdAt', 'DESC')
+      .limit(limit)
+      .getMany();
+
+    return result.map((streak, index) => ({
+      rank: index + 1,
+      userId: streak.user.id,
+      username: streak.user.username,
+      habitId: streak.habit.id,
+      habitName: streak.habit.name,
+      categoryId: streak.habit.category.id,
+      categoryName: streak.habit.category.name,
+      streakCount: streak.count,
+      isActive: streak.isActive,
+    }));
+  } catch (error) {
+    console.error('Error in getTopStreaksByCategory:', error);
+    return [];
+  }
+}
+
+export async function getTopStreaksByUser(
+  limit: number = 10
+): Promise<UserStreakLeaderboardEntry[]> {
+  await ensureDbConnected();
+  
+  try {
+    const result = await streakRepository
+      .createQueryBuilder('streak')
+      .innerJoinAndSelect('streak.user', 'user')
+      .innerJoinAndSelect('streak.habit', 'habit')
+      .innerJoinAndSelect('habit.category', 'category')
+      .where('streak.count > :minCount', { minCount: 0 })
+      .orderBy('streak.count', 'DESC')
+      .addOrderBy('streak.createdAt', 'DESC')
+      .limit(limit)
+      .getMany();
+
+    return result.map((streak, index) => ({
+      rank: index + 1,
+      userId: streak.user.id,
+      username: streak.user.username,
+      streakCount: streak.count,
+      topStreakHabit: {
+        habitId: streak.habit.id,
+        habitName: streak.habit.name,
+        categoryId: streak.habit.category.id,
+        categoryName: streak.habit.category.name,
+      },
+      isActive: streak.isActive,
+    }));
+  } catch (error) {
+    console.error('Error in getTopStreaksByUser:', error);
+    return [];
+  }
+}
+
+export async function getTopLevelsByCategory(
+  categoryId: string,
+  limit: number = 10
+): Promise<CategoryLevelLeaderboardEntry[]> {
+  await ensureDbConnected();
+  
+  const result = await userCategoryExperienceRepo
+    .createQueryBuilder('uce')
+    .leftJoinAndSelect('uce.user', 'user')
+    .leftJoinAndSelect('uce.category', 'category')
+    .where('uce.categoryId = :categoryId', { categoryId })
+    .orderBy('uce.totalExperience', 'DESC')
+    .limit(limit)
+    .getMany();
+
+  const experienceCalculator = new ExperienceCalculator();
+
+  return result.map((uce, index) => {
+    const levelInfo = experienceCalculator.calculateLevelInfo(uce.totalExperience);
+    
+    return {
+      rank: index + 1,
+      userId: uce.userId,
+      username: uce.user.username,
+      categoryId: uce.categoryId,
+      categoryName: uce.category.name,
+      totalExperience: uce.totalExperience,
+      level: levelInfo.currentLevel,
+    };
+  });
+}
+
+export async function getTopLevelsByUser(
+  limit: number = 10
+): Promise<UserLevelLeaderboardEntry[]> {
+  await ensureDbConnected();
+  
+  const result = await userCategoryExperienceRepo
+    .createQueryBuilder('uce')
+    .leftJoinAndSelect('uce.user', 'user')
+    .select([
+      'uce.userId as "userId"',
+      'user.username as username',
+      'SUM(uce.totalExperience) as "totalExperience"',
+      'COUNT(uce.categoryId) as "categoriesCount"'
+    ])
+    .groupBy('uce.userId, user.username')
+    .orderBy('SUM(uce.totalExperience)', 'DESC')
+    .limit(limit)
+    .getRawMany();
+
+  const experienceCalculator = new ExperienceCalculator();
+
+  const userLevelPromises = result.map(async (row) => {
+    const categoryExperiences = await userCategoryExperienceRepo.find({
+      where: { userId: row.userId },
+      relations: ['category'],
+      order: { totalExperience: 'DESC' },
+    });
+
+    const categoryExpData = categoryExperiences.map(ce => ({
+      categoryId: ce.categoryId,
+      totalExperience: ce.totalExperience,
+    }));
+
+    const userLevelInfo = experienceCalculator.calculateUserLevel(categoryExpData);
+
+    const topCategoryExp = categoryExperiences[0];
+    const topCategory = topCategoryExp ? {
+      categoryId: topCategoryExp.categoryId,
+      categoryName: topCategoryExp.category.name,
+      level: experienceCalculator.calculateLevelInfo(topCategoryExp.totalExperience).currentLevel,
+      experience: topCategoryExp.totalExperience,
+    } : null;
+
+    return {
+      rank: 0,
+      userId: row.userId,
+      username: row.username,
+      totalExperience: Number(row.totalExperience),
+      totalLevel: userLevelInfo.totalLevel,
+      categoriesCount: Number(row.categoriesCount),
+      topCategory,
+    };
+  });
+
+  const results = await Promise.all(userLevelPromises);
+  
+  results.sort((a, b) => {
+    if (b.totalLevel !== a.totalLevel) {
+      return b.totalLevel - a.totalLevel;
+    }
+    return b.totalExperience - a.totalExperience;
+  });
+
+  return results.map((entry, index) => ({
+    ...entry,
+    rank: index + 1,
+  }));
+}

--- a/src/entities/Habit.ts
+++ b/src/entities/Habit.ts
@@ -1,4 +1,4 @@
-import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, ManyToOne, OneToMany } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, ManyToOne, OneToMany, JoinColumn } from 'typeorm';
 import { User } from './User';
 import { Category } from './Category';
 import { Streak } from './Streak';
@@ -19,10 +19,18 @@ export class Habit {
 	@Column({ type: 'timestamp', nullable: true })
 	startDate: Date | null;
 
+  @Column({ type: 'uuid' })
+  userId: string;
+
+  @Column({ type: 'uuid' })
+  categoryId: string;
+
   @ManyToOne(() => User, user => user.habits, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'userId' })
   user: User;
 
   @ManyToOne(() => Category, category => category.habits, { onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'categoryId' })
   category: Category;
 
 	@Column({

--- a/src/entities/Streak.ts
+++ b/src/entities/Streak.ts
@@ -1,4 +1,4 @@
-import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn, ManyToOne, OneToMany } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn, ManyToOne, OneToMany, JoinColumn } from 'typeorm';
 import { User } from './User';
 import { Habit } from './Habit';
 import { HabitTask } from './HabitTask';
@@ -26,10 +26,18 @@ export class Streak {
   @UpdateDateColumn({ type: 'timestamptz' })
   updatedAt: Date;
 
+  @Column({ type: 'uuid' })
+  userId: string;
+
+  @Column({ type: 'uuid' })
+  habitId: string;
+
   @ManyToOne(() => User, user => user.streaks, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'userId' })
   user: User;
 
   @ManyToOne(() => Habit, habit => habit.streaks, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'habitId' })
   habit: Habit;
 
   @OneToMany(() => HabitTask, habitTask => habitTask.streak, { cascade: true })

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -4,6 +4,7 @@ import habitRoutes from './habitRoutes';
 import categoryRoutes from './categoryRoutes';
 import friendRoutes from './friendRoutes';
 import experienceRoutes from './experienceRoutes';
+import leaderboardRoutes from './leaderboardRoutes';
 
 const router = Router();
 
@@ -12,6 +13,7 @@ router.use('/api/habits', habitRoutes);
 router.use('/api/categories', categoryRoutes);
 router.use('/api/friends', friendRoutes);
 router.use('/api/experience', experienceRoutes);
+router.use('/api/leaderboards', leaderboardRoutes);
 
 export default router;
 

--- a/src/routes/leaderboardRoutes.ts
+++ b/src/routes/leaderboardRoutes.ts
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import { getLeaderboard } from '../controllers/leaderboardController';
+
+const router = Router();
+
+router.get('/', getLeaderboard);
+
+export default router;

--- a/src/validators/leaderboardValidators.ts
+++ b/src/validators/leaderboardValidators.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod';
+
+export const leaderboardTypeEnum = z.enum([
+  'streak-by-category',
+  'streak-by-user', 
+  'level-by-category',
+  'level-by-user'
+]);
+
+export const leaderboardQuerySchema = z.object({
+  type: leaderboardTypeEnum,
+  categoryId: z.string().uuid('Invalid category ID format').optional(),
+  limit: z.coerce.number().min(1).max(50).optional().default(10),
+}).refine((data) => {
+  if (data.type === 'streak-by-category' || data.type === 'level-by-category') {
+    return data.categoryId !== undefined;
+  }
+  return true;
+}, {
+  message: 'categoryId is required for category-specific leaderboard types',
+  path: ['categoryId']
+}).transform((data) => {
+  if (data.type === 'streak-by-user' || data.type === 'level-by-user') {
+    return { ...data, categoryId: undefined };
+  }
+  return data;
+});
+
+export type LeaderboardType = z.infer<typeof leaderboardTypeEnum>;
+export type LeaderboardQuery = z.infer<typeof leaderboardQuerySchema>;


### PR DESCRIPTION
Added GET /api/leaderboards route with support for 4 leaderboard types:
Query Parameters:
  - type: "streak-by-user" | "level-by-user" | "streak-by-category" | "level-by-category"
  - categoryId: string (required when type contains "by-category")
  - limit: number (optional, default: 10)

  Usage Examples:
  GET /api/leaderboards?type=streak-by-user&limit=5
  GET /api/leaderboards?type=streak-by-category&categoryId=uuid&limit=10
  GET /api/leaderboards?type=level-by-user
  GET /api/leaderboards?type=level-by-category&categoryId=uuid